### PR TITLE
several fixes to te all schemas

### DIFF
--- a/components/openehr_api_1.0.2_all.json
+++ b/components/openehr_api_1.0.2_all.json
@@ -353,7 +353,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer"
             ],
@@ -3565,7 +3564,6 @@
         "CONTRIBUTION": {
             "type": "object",
             "required": [
-                "uid",
                 "audit",
                 "versions"
             ],
@@ -3642,14 +3640,8 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "COMPOSITION",
-                                            "FOLDER",
-                                            "EHR_STATUS",
-                                            "ROLE",
-                                            "AGENT",
-                                            "GROUP",
-                                            "ORGANISATION",
-                                            "PERSON"
+                                            "ORIGINAL_VERSION",
+                                            "IMPORTED_VERSION"
                                         ]
                                     }
                                 }
@@ -3658,7 +3650,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "COMPOSITION"
+                                            "const": "ORIGINAL_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3666,14 +3658,14 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/COMPOSITION"
+                                    "$ref": "#/definitions/ORIGINAL_VERSION"
                                 }
                             },
                             {
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "FOLDER"
+                                            "const": "IMPORTED_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3681,97 +3673,7 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/FOLDER"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "EHR_STATUS"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/EHR_STATUS"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ROLE"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ROLE"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "AGENT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/AGENT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "GROUP"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/GROUP"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ORGANISATION"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ORGANISATION"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PERSON"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PERSON"
+                                    "$ref": "#/definitions/IMPORTED_VERSION"
                                 }
                             }
                         ]
@@ -4003,7 +3905,6 @@
             "required": [
                 "contribution",
                 "commit_audit",
-                "uid",
                 "lifecycle_state"
             ],
             "properties": {
@@ -9861,7 +9762,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name"
             ],
             "properties": {
@@ -11801,7 +11701,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer",
                 "reason",

--- a/components/openehr_api_1.0.2_all.json
+++ b/components/openehr_api_1.0.2_all.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_rm_1.0.3_all.json",
+    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_api_1.0.2_all.json",
     "allOf": [
         {
             "required": [
@@ -508,7 +508,6 @@
                 "system_id",
                 "ehr_id",
                 "time_created",
-                "ehr_access",
                 "ehr_status"
             ],
             "properties": {
@@ -522,134 +521,10 @@
                     "$ref": "#/definitions/DV_DATE_TIME"
                 },
                 "ehr_access": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "ACCESS_GROUP_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_ACCESS"
                 },
                 "ehr_status": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_STATUS"
                 },
                 "directory": {
                     "allOf": [
@@ -2561,7 +2436,6 @@
         "PERSON": {
             "type": "object",
             "required": [
-                "uid",
                 "archetype_node_id",
                 "archetype_details",
                 "name",
@@ -3761,11 +3635,21 @@
                     "items": {
                         "allOf": [
                             {
+                                "required": [
+                                    "_type"
+                                ],
                                 "properties": {
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "OBJECT_REF"
+                                            "COMPOSITION",
+                                            "FOLDER",
+                                            "EHR_STATUS",
+                                            "ROLE",
+                                            "AGENT",
+                                            "GROUP",
+                                            "ORGANISATION",
+                                            "PERSON"
                                         ]
                                     }
                                 }
@@ -3774,7 +3658,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "OBJECT_REF"
+                                            "const": "COMPOSITION"
                                         }
                                     },
                                     "required": [
@@ -3782,19 +3666,112 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/COMPOSITION"
                                 }
                             },
                             {
                                 "if": {
-                                    "not": {
-                                        "required": [
-                                            "_type"
-                                        ]
-                                    }
+                                    "properties": {
+                                        "_type": {
+                                            "const": "FOLDER"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/FOLDER"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "EHR_STATUS"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/EHR_STATUS"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ROLE"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ROLE"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "AGENT"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/AGENT"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "GROUP"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/GROUP"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ORGANISATION"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ORGANISATION"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "PERSON"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/PERSON"
                                 }
                             }
                         ]
@@ -5677,7 +5654,6 @@
         "ROLE": {
             "type": "object",
             "required": [
-                "uid",
                 "archetype_node_id",
                 "archetype_details",
                 "name",
@@ -5919,7 +5895,6 @@
         "AGENT": {
             "type": "object",
             "required": [
-                "uid",
                 "archetype_node_id",
                 "archetype_details",
                 "name",
@@ -6387,7 +6362,6 @@
         "GROUP": {
             "type": "object",
             "required": [
-                "uid",
                 "archetype_node_id",
                 "archetype_details",
                 "name",
@@ -9664,66 +9638,6 @@
                 "careflow_step": {
                     "$ref": "#/definitions/DV_CODED_TEXT"
                 },
-                "reason": {
-                    "type": "array",
-                    "items": {
-                        "allOf": [
-                            {
-                                "properties": {
-                                    "_type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "DV_CODED_TEXT",
-                                            "DV_TEXT"
-                                        ]
-                                    }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "DV_CODED_TEXT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/DV_CODED_TEXT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "DV_TEXT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/DV_TEXT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "not": {
-                                        "required": [
-                                            "_type"
-                                        ]
-                                    }
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/DV_TEXT"
-                                }
-                            }
-                        ]
-                    }
-                },
                 "_type": {
                     "type": "string",
                     "const": "ISM_TRANSITION"
@@ -9814,7 +9728,8 @@
             "type": "object",
             "required": [
                 "function",
-                "performer"
+                "performer",
+                "mode"
             ],
             "properties": {
                 "function": {
@@ -10437,7 +10352,6 @@
         "ORGANISATION": {
             "type": "object",
             "required": [
-                "uid",
                 "archetype_node_id",
                 "archetype_details",
                 "name",
@@ -10748,57 +10662,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {

--- a/components/openehr_api_1.0.3_all.json
+++ b/components/openehr_api_1.0.3_all.json
@@ -365,7 +365,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer"
             ],
@@ -3579,7 +3578,6 @@
         "CONTRIBUTION": {
             "type": "object",
             "required": [
-                "uid",
                 "audit",
                 "versions"
             ],
@@ -3656,14 +3654,8 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "COMPOSITION",
-                                            "FOLDER",
-                                            "EHR_STATUS",
-                                            "ROLE",
-                                            "AGENT",
-                                            "GROUP",
-                                            "ORGANISATION",
-                                            "PERSON"
+                                            "ORIGINAL_VERSION",
+                                            "IMPORTED_VERSION"
                                         ]
                                     }
                                 }
@@ -3672,7 +3664,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "COMPOSITION"
+                                            "const": "ORIGINAL_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3680,14 +3672,14 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/COMPOSITION"
+                                    "$ref": "#/definitions/ORIGINAL_VERSION"
                                 }
                             },
                             {
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "FOLDER"
+                                            "const": "IMPORTED_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3695,97 +3687,7 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/FOLDER"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "EHR_STATUS"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/EHR_STATUS"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ROLE"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ROLE"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "AGENT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/AGENT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "GROUP"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/GROUP"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ORGANISATION"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ORGANISATION"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PERSON"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PERSON"
+                                    "$ref": "#/definitions/IMPORTED_VERSION"
                                 }
                             }
                         ]
@@ -4017,7 +3919,6 @@
             "required": [
                 "contribution",
                 "commit_audit",
-                "uid",
                 "lifecycle_state"
             ],
             "properties": {
@@ -11879,7 +11780,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer",
                 "reason",

--- a/components/openehr_api_1.0.3_all.json
+++ b/components/openehr_api_1.0.3_all.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_rm_1.0.3_all.json",
+    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_api_1.0.3_all.json",
     "allOf": [
         {
             "required": [
@@ -143,12 +143,36 @@
             "if": {
                 "properties": {
                     "_type": {
+                        "const": "CAPABILITY"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/CAPABILITY"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
                         "const": "PERSON"
                     }
                 }
             },
             "then": {
                 "$ref": "#/definitions/PERSON"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ADDRESS"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ADDRESS"
             }
         },
         {
@@ -179,24 +203,12 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "AGENT"
+                        "const": "PARTY_IDENTITY"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/AGENT"
-            }
-        },
-        {
-            "if": {
-               "properties": {
-                  "_type": {
-                        "const": "GROUP"
-                  }
-               }
-            },
-            "then": {
-               "$ref": "#/definitions/GROUP"
+                "$ref": "#/definitions/PARTY_IDENTITY"
             }
         },
         {
@@ -508,7 +520,6 @@
                 "system_id",
                 "ehr_id",
                 "time_created",
-                "ehr_access",
                 "ehr_status"
             ],
             "properties": {
@@ -522,134 +533,10 @@
                     "$ref": "#/definitions/DV_DATE_TIME"
                 },
                 "ehr_access": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "ACCESS_GROUP_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_ACCESS"
                 },
                 "ehr_status": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_STATUS"
                 },
                 "directory": {
                     "allOf": [
@@ -2563,9 +2450,10 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
-                "identities"
+                "identities",
+                "roles",
+                "languages"
             ],
             "properties": {
                 "uid": {
@@ -3761,11 +3649,21 @@
                     "items": {
                         "allOf": [
                             {
+                                "required": [
+                                    "_type"
+                                ],
                                 "properties": {
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "OBJECT_REF"
+                                            "COMPOSITION",
+                                            "FOLDER",
+                                            "EHR_STATUS",
+                                            "ROLE",
+                                            "AGENT",
+                                            "GROUP",
+                                            "ORGANISATION",
+                                            "PERSON"
                                         ]
                                     }
                                 }
@@ -3774,7 +3672,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "OBJECT_REF"
+                                            "const": "COMPOSITION"
                                         }
                                     },
                                     "required": [
@@ -3782,19 +3680,112 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/COMPOSITION"
                                 }
                             },
                             {
                                 "if": {
-                                    "not": {
-                                        "required": [
-                                            "_type"
-                                        ]
-                                    }
+                                    "properties": {
+                                        "_type": {
+                                            "const": "FOLDER"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/FOLDER"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "EHR_STATUS"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/EHR_STATUS"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ROLE"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ROLE"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "AGENT"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/AGENT"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "GROUP"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/GROUP"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ORGANISATION"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ORGANISATION"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "PERSON"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/PERSON"
                                 }
                             }
                         ]
@@ -5679,7 +5670,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities",
                 "performer"
@@ -5921,9 +5911,10 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
-                "identities"
+                "identities",
+                "roles",
+                "languages"
             ],
             "properties": {
                 "uid": {
@@ -6389,9 +6380,10 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
-                "identities"
+                "identities",
+                "roles",
+                "languages"
             ],
             "properties": {
                 "uid": {
@@ -9946,7 +9938,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name"
             ],
             "properties": {
@@ -10439,9 +10430,10 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
-                "identities"
+                "identities",
+                "roles",
+                "languages"
             ],
             "properties": {
                 "uid": {
@@ -10748,57 +10740,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -13746,7 +13690,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "language",
                 "territory",
@@ -14058,7 +14001,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "subject",
                 "is_queryable",

--- a/components/openehr_api_1.0.4_all.json
+++ b/components/openehr_api_1.0.4_all.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_rm_1.0.3_all.json",
+    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_api_1.0.4_all.json",
     "allOf": [
         {
             "required": [
@@ -143,12 +143,36 @@
             "if": {
                 "properties": {
                     "_type": {
+                        "const": "CAPABILITY"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/CAPABILITY"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
                         "const": "PERSON"
                     }
                 }
             },
             "then": {
                 "$ref": "#/definitions/PERSON"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ADDRESS"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ADDRESS"
             }
         },
         {
@@ -179,24 +203,12 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "AGENT"
+                        "const": "PARTY_IDENTITY"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/AGENT"
-            }
-        },
-        {
-            "if": {
-               "properties": {
-                  "_type": {
-                        "const": "GROUP"
-                  }
-               }
-            },
-            "then": {
-               "$ref": "#/definitions/GROUP"
+                "$ref": "#/definitions/PARTY_IDENTITY"
             }
         },
         {
@@ -321,6 +333,17 @@
         }
     ],
     "definitions": {
+        "VERSION_STATUS": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "VERSION_STATUS"
+                }
+            }
+        },
         "SYNC_EXTRACT_SPEC": {
             "type": "object",
             "required": [
@@ -508,7 +531,6 @@
                 "system_id",
                 "ehr_id",
                 "time_created",
-                "ehr_access",
                 "ehr_status"
             ],
             "properties": {
@@ -522,134 +544,10 @@
                     "$ref": "#/definitions/DV_DATE_TIME"
                 },
                 "ehr_access": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "ACCESS_GROUP_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_ACCESS"
                 },
                 "ehr_status": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_STATUS"
                 },
                 "directory": {
                     "allOf": [
@@ -2563,7 +2461,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -3761,20 +3658,31 @@
                     "items": {
                         "allOf": [
                             {
+                                "required": [
+                                    "_type"
+                                ],
                                 "properties": {
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "OBJECT_REF"
+                                            "COMPOSITION",
+                                            "FOLDER",
+                                            "EHR_STATUS",
+                                            "ROLE",
+                                            "AGENT",
+                                            "GROUP",
+                                            "ORGANISATION",
+                                            "PERSON"
                                         ]
                                     }
                                 }
                             },
+                            
                             {
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "OBJECT_REF"
+                                            "const": "COMPOSITION"
                                         }
                                     },
                                     "required": [
@@ -3782,19 +3690,112 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/COMPOSITION"
                                 }
                             },
                             {
                                 "if": {
-                                    "not": {
-                                        "required": [
-                                            "_type"
-                                        ]
-                                    }
+                                    "properties": {
+                                        "_type": {
+                                            "const": "FOLDER"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/FOLDER"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "EHR_STATUS"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/EHR_STATUS"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ROLE"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ROLE"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "AGENT"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/AGENT"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "GROUP"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/GROUP"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ORGANISATION"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ORGANISATION"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "PERSON"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/PERSON"
                                 }
                             }
                         ]
@@ -5519,6 +5520,17 @@
             },
             "additionalProperties": false
         },
+        "URI": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "URI"
+                }
+            }
+        },
         "SYNC_EXTRACT": {
             "type": "object",
             "required": [
@@ -5674,12 +5686,38 @@
             },
             "additionalProperties": false
         },
+        "TERMINOLOGY_CODE": {
+            "type": "object",
+            "required": [
+                "terminology_id",
+                "code_string",
+                "uri"
+            ],
+            "properties": {
+                "terminology_id": {
+                    "type": "string"
+                },
+                "terminology_version": {
+                    "type": "string"
+                },
+                "code_string": {
+                    "type": "string"
+                },
+                "uri": {
+                    "$ref": "#/definitions/URI"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "TERMINOLOGY_CODE"
+                }
+            },
+            "additionalProperties": false
+        },
         "ROLE": {
             "type": "object",
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities",
                 "performer"
@@ -5921,7 +5959,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -6389,7 +6426,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -8373,6 +8409,22 @@
             },
             "additionalProperties": false
         },
+        "DURATION": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DURATION"
+                }
+            },
+            "description": "Duration type based on IS8601 representation.",
+            "additionalProperties": false
+        },
         "HISTORY": {
             "type": "object",
             "required": [
@@ -9946,7 +9998,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name"
             ],
             "properties": {
@@ -10384,6 +10435,17 @@
             },
             "additionalProperties": false
         },
+        "VALIDITY_KIND": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "VALIDITY_KIND"
+                }
+            }
+        },
         "OBJECT_VERSION_ID": {
             "type": "object",
             "required": [
@@ -10439,7 +10501,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -10748,57 +10809,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -11513,6 +11526,22 @@
                     "const": "GENERIC_CONTENT_ITEM"
                 }
             },
+            "additionalProperties": false
+        },
+        "DATE": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DATE"
+                }
+            },
+            "description": "Date type based on IS8601 representation.",
             "additionalProperties": false
         },
         "ITEM_TABLE": {
@@ -12543,6 +12572,22 @@
             },
             "additionalProperties": false
         },
+        "DATE_TIME": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DATE_TIME"
+                }
+            },
+            "description": "Date Time type based on IS8601 representation.",
+            "additionalProperties": false
+        },
         "PARTY_RELATIONSHIP": {
             "type": "object",
             "required": [
@@ -12897,7 +12942,6 @@
         "DV_EHR_URI": {
             "type": "object",
             "required": [
-                "value"
             ],
             "properties": {
                 "value": {
@@ -12907,6 +12951,26 @@
                 "_type": {
                     "type": "string",
                     "const": "DV_EHR_URI"
+                }
+            },
+            "additionalProperties": false
+        },
+        "TERMINOLOGY_TERM": {
+            "type": "object",
+            "required": [
+                "text",
+                "concept"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "concept": {
+                    "$ref": "#/definitions/TERMINOLOGY_CODE"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "TERMINOLOGY_TERM"
                 }
             },
             "additionalProperties": false
@@ -13746,7 +13810,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "language",
                 "territory",
@@ -14058,7 +14121,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "subject",
                 "is_queryable",
@@ -14785,6 +14847,22 @@
             },
             "additionalProperties": false
         },
+        "TIME": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "TIME"
+                }
+            },
+            "description": "Time type based on IS8601 representation.",
+            "additionalProperties": false
+        },
         "IMPORTED_VERSION": {
             "type": "object",
             "required": [
@@ -14923,7 +15001,6 @@
         "DV_URI": {
             "type": "object",
             "required": [
-                "value"
             ],
             "properties": {
                 "value": {
@@ -16059,8 +16136,7 @@
                 "archetype_node_id",
                 "name",
                 "description",
-                "action_archetype_id",
-                "timing"
+                "action_archetype_id"
             ],
             "properties": {
                 "uid": {

--- a/components/openehr_api_1.0.4_all.json
+++ b/components/openehr_api_1.0.4_all.json
@@ -376,7 +376,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer"
             ],
@@ -3588,7 +3587,6 @@
         "CONTRIBUTION": {
             "type": "object",
             "required": [
-                "uid",
                 "audit",
                 "versions"
             ],
@@ -3665,14 +3663,8 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "COMPOSITION",
-                                            "FOLDER",
-                                            "EHR_STATUS",
-                                            "ROLE",
-                                            "AGENT",
-                                            "GROUP",
-                                            "ORGANISATION",
-                                            "PERSON"
+                                            "ORIGINAL_VERSION",
+                                            "IMPORTED_VERSION"
                                         ]
                                     }
                                 }
@@ -3682,7 +3674,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "COMPOSITION"
+                                            "const": "ORIGINAL_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3690,14 +3682,14 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/COMPOSITION"
+                                    "$ref": "#/definitions/ORIGINAL_VERSION"
                                 }
                             },
                             {
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "FOLDER"
+                                            "const": "IMPORTED_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3705,97 +3697,7 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/FOLDER"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "EHR_STATUS"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/EHR_STATUS"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ROLE"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ROLE"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "AGENT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/AGENT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "GROUP"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/GROUP"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ORGANISATION"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ORGANISATION"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PERSON"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PERSON"
+                                    "$ref": "#/definitions/IMPORTED_VERSION"
                                 }
                             }
                         ]
@@ -4027,7 +3929,6 @@
             "required": [
                 "contribution",
                 "commit_audit",
-                "uid",
                 "lifecycle_state"
             ],
             "properties": {
@@ -11964,7 +11865,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer",
                 "reason",

--- a/components/openehr_api_1.1.0_all.json
+++ b/components/openehr_api_1.1.0_all.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_rm_1.0.3_all.json",
+    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_api_1.1.0_all.json",
     "allOf": [
         {
             "required": [
@@ -138,6 +138,18 @@
             "then": {
                 "$ref": "#/definitions/ELEMENT"
             }
+        }
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "CAPABILITY"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/CAPABILITY"
+            }
         },
         {
             "if": {
@@ -149,6 +161,18 @@
             },
             "then": {
                 "$ref": "#/definitions/PERSON"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ADDRESS"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ADDRESS"
             }
         },
         {
@@ -179,24 +203,12 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "AGENT"
+                        "const": "PARTY_IDENTITY"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/AGENT"
-            }
-        },
-        {
-            "if": {
-               "properties": {
-                  "_type": {
-                        "const": "GROUP"
-                  }
-               }
-            },
-            "then": {
-               "$ref": "#/definitions/GROUP"
+                "$ref": "#/definitions/PARTY_IDENTITY"
             }
         },
         {
@@ -321,6 +333,17 @@
         }
     ],
     "definitions": {
+        "VERSION_STATUS": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "VERSION_STATUS"
+                }
+            }
+        },
         "SYNC_EXTRACT_SPEC": {
             "type": "object",
             "required": [
@@ -508,7 +531,6 @@
                 "system_id",
                 "ehr_id",
                 "time_created",
-                "ehr_access",
                 "ehr_status"
             ],
             "properties": {
@@ -522,134 +544,10 @@
                     "$ref": "#/definitions/DV_DATE_TIME"
                 },
                 "ehr_access": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "ACCESS_GROUP_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_ACCESS"
                 },
                 "ehr_status": {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "LOCATABLE_REF",
-                                        "OBJECT_REF"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "not": {
-                                    "required": [
-                                        "_type"
-                                    ]
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_REF"
-                            }
-                        }
-                    ]
+                    "$ref": "#/definitions/EHR_STATUS"
                 },
                 "directory": {
                     "allOf": [
@@ -707,6 +605,66 @@
                             }
                         }
                     ]
+                },
+                "folders": {
+                    "type": "array",
+                    "items": {
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "LOCATABLE_REF",
+                                            "OBJECT_REF"
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "LOCATABLE_REF"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/LOCATABLE_REF"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "OBJECT_REF"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/OBJECT_REF"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "not": {
+                                        "required": [
+                                            "_type"
+                                        ]
+                                    }
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/OBJECT_REF"
+                                }
+                            }
+                        ]
+                    }
                 },
                 "compositions": {
                     "type": "array",
@@ -947,6 +905,50 @@
                 "_type": {
                     "type": "string",
                     "const": "REVISION_HISTORY_ITEM"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ARCHETYPE_HRID": {
+            "type": "object",
+            "required": [
+                "namespace",
+                "rm_publisher",
+                "rm_package",
+                "rm_class",
+                "concept_id",
+                "release_version",
+                "version_status",
+                "build_count"
+            ],
+            "properties": {
+                "namespace": {
+                    "type": "string"
+                },
+                "rm_publisher": {
+                    "type": "string"
+                },
+                "rm_package": {
+                    "type": "string"
+                },
+                "rm_class": {
+                    "type": "string"
+                },
+                "concept_id": {
+                    "type": "string"
+                },
+                "release_version": {
+                    "type": "string"
+                },
+                "version_status": {
+                    "$ref": "#/definitions/VERSION_STATUS"
+                },
+                "build_count": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "ARCHETYPE_HRID"
                 }
             },
             "additionalProperties": false
@@ -2563,7 +2565,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -3761,11 +3762,21 @@
                     "items": {
                         "allOf": [
                             {
+                                "required": [
+                                    "_type"
+                                ],
                                 "properties": {
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "OBJECT_REF"
+                                            "COMPOSITION",
+                                            "FOLDER",
+                                            "EHR_STATUS",
+                                            "ROLE",
+                                            "AGENT",
+                                            "GROUP",
+                                            "ORGANISATION",
+                                            "PERSON"
                                         ]
                                     }
                                 }
@@ -3774,7 +3785,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "OBJECT_REF"
+                                            "const": "COMPOSITION"
                                         }
                                     },
                                     "required": [
@@ -3782,19 +3793,112 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/COMPOSITION"
                                 }
                             },
                             {
                                 "if": {
-                                    "not": {
-                                        "required": [
-                                            "_type"
-                                        ]
-                                    }
+                                    "properties": {
+                                        "_type": {
+                                            "const": "FOLDER"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/OBJECT_REF"
+                                    "$ref": "#/definitions/FOLDER"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "EHR_STATUS"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/EHR_STATUS"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ROLE"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ROLE"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "AGENT"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/AGENT"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "GROUP"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/GROUP"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "ORGANISATION"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/ORGANISATION"
+                                }
+                            },
+                            {
+                                "if": {
+                                    "properties": {
+                                        "_type": {
+                                            "const": "PERSON"
+                                        }
+                                    },
+                                    "required": [
+                                        "_type"
+                                    ]
+                                },
+                                "then": {
+                                    "$ref": "#/definitions/PERSON"
                                 }
                             }
                         ]
@@ -4013,6 +4117,74 @@
                 },
                 "version_id": {
                     "type": "string"
+                },
+                "other_details": {
+                    "allOf": [
+                        {
+                            "required": [
+                                "_type"
+                            ],
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "ITEM_SINGLE",
+                                        "ITEM_TREE",
+                                        "ITEM_LIST",
+                                        "ITEM_TABLE"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_SINGLE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_SINGLE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_TREE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_TREE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_LIST"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_LIST"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_TABLE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_TABLE"
+                            }
+                        }
+                    ]
                 },
                 "_type": {
                     "type": "string",
@@ -4586,6 +4758,9 @@
                     "$ref": "#/definitions/TERMINOLOGY_ID"
                 },
                 "code_string": {
+                    "type": "string"
+                },
+                "preferred_term": {
                     "type": "string"
                 },
                 "_type": {
@@ -5318,6 +5493,12 @@
                 "units": {
                     "type": "string"
                 },
+                "units_system": {
+                    "type": "string"
+                },
+                "units_display_name": {
+                    "type": "string"
+                },
                 "precision": {
                     "type": "integer"
                 },
@@ -5519,6 +5700,17 @@
             },
             "additionalProperties": false
         },
+        "URI": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "URI"
+                }
+            }
+        },
         "SYNC_EXTRACT": {
             "type": "object",
             "required": [
@@ -5674,12 +5866,38 @@
             },
             "additionalProperties": false
         },
+        "TERMINOLOGY_CODE": {
+            "type": "object",
+            "required": [
+                "terminology_id",
+                "code_string",
+                "uri"
+            ],
+            "properties": {
+                "terminology_id": {
+                    "type": "string"
+                },
+                "terminology_version": {
+                    "type": "string"
+                },
+                "code_string": {
+                    "type": "string"
+                },
+                "uri": {
+                    "$ref": "#/definitions/URI"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "TERMINOLOGY_CODE"
+                }
+            },
+            "additionalProperties": false
+        },
         "ROLE": {
             "type": "object",
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities",
                 "performer"
@@ -5921,7 +6139,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -6389,7 +6606,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -7837,6 +8053,18 @@
                             "if": {
                                 "properties": {
                                     "_type": {
+                                        "const": "DV_SCALE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/DV_SCALE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
                                         "const": "DV_COUNT"
                                     }
                                 }
@@ -8047,6 +8275,63 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/DV_CODED_TEXT"
+                            }
+                        }
+                    ]
+                },
+                "null_reason": {
+                    "allOf": [
+                        {
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "DV_CODED_TEXT",
+                                        "DV_TEXT"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "DV_CODED_TEXT"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/DV_CODED_TEXT"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "DV_TEXT"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/DV_TEXT"
+                            }
+                        },
+                        {
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "_type"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/DV_TEXT"
                             }
                         }
                     ]
@@ -8371,6 +8656,22 @@
                     "const": "ITEM_LIST"
                 }
             },
+            "additionalProperties": false
+        },
+        "DURATION": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DURATION"
+                }
+            },
+            "description": "Duration type based on IS8601 representation.",
             "additionalProperties": false
         },
         "HISTORY": {
@@ -9946,7 +10247,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name"
             ],
             "properties": {
@@ -10163,6 +10463,74 @@
                             }
                         ]
                     }
+                },
+                "details": {
+                    "allOf": [
+                        {
+                            "required": [
+                                "_type"
+                            ],
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "ITEM_SINGLE",
+                                        "ITEM_TREE",
+                                        "ITEM_LIST",
+                                        "ITEM_TABLE"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_SINGLE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_SINGLE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_TREE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_TREE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_LIST"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_LIST"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ITEM_TABLE"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ITEM_TABLE"
+                            }
+                        }
+                    ]
                 },
                 "_type": {
                     "type": "string",
@@ -10384,6 +10752,17 @@
             },
             "additionalProperties": false
         },
+        "VALIDITY_KIND": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "VALIDITY_KIND"
+                }
+            }
+        },
         "OBJECT_VERSION_ID": {
             "type": "object",
             "required": [
@@ -10439,7 +10818,6 @@
             "required": [
                 "uid",
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -10748,57 +11126,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -11513,6 +11843,22 @@
                     "const": "GENERIC_CONTENT_ITEM"
                 }
             },
+            "additionalProperties": false
+        },
+        "DATE": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DATE"
+                }
+            },
+            "description": "Date type based on IS8601 representation.",
             "additionalProperties": false
         },
         "ITEM_TABLE": {
@@ -12543,6 +12889,22 @@
             },
             "additionalProperties": false
         },
+        "DATE_TIME": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DATE_TIME"
+                }
+            },
+            "description": "Date Time type based on IS8601 representation.",
+            "additionalProperties": false
+        },
         "PARTY_RELATIONSHIP": {
             "type": "object",
             "required": [
@@ -12897,7 +13259,6 @@
         "DV_EHR_URI": {
             "type": "object",
             "required": [
-                "value"
             ],
             "properties": {
                 "value": {
@@ -12907,6 +13268,59 @@
                 "_type": {
                     "type": "string",
                     "const": "DV_EHR_URI"
+                }
+            },
+            "additionalProperties": false
+        },
+        "TERMINOLOGY_TERM": {
+            "type": "object",
+            "required": [
+                "text",
+                "concept"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "concept": {
+                    "$ref": "#/definitions/TERMINOLOGY_CODE"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "TERMINOLOGY_TERM"
+                }
+            },
+            "additionalProperties": false
+        },
+        "DV_SCALE": {
+            "type": "object",
+            "required": [
+                "value",
+                "symbol"
+            ],
+            "properties": {
+                "normal_status": {
+                    "$ref": "#/definitions/CODE_PHRASE"
+                },
+                "normal_range": {
+                    "$ref": "#/definitions/DV_INTERVAL"
+                },
+                "other_reference_ranges": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/REFERENCE_RANGE"
+                    },
+                    "minItems": 1
+                },
+                "value": {
+                    "type": "number"
+                },
+                "symbol": {
+                    "$ref": "#/definitions/DV_CODED_TEXT"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "DV_SCALE"
                 }
             },
             "additionalProperties": false
@@ -13746,7 +14160,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "language",
                 "territory",
@@ -14058,7 +14471,6 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
-                "archetype_details",
                 "name",
                 "subject",
                 "is_queryable",
@@ -14785,6 +15197,22 @@
             },
             "additionalProperties": false
         },
+        "TIME": {
+            "type": "object",
+            "required": [
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "TIME"
+                }
+            },
+            "description": "Time type based on IS8601 representation.",
+            "additionalProperties": false
+        },
         "IMPORTED_VERSION": {
             "type": "object",
             "required": [
@@ -14800,9 +15228,57 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
+                                        "LOCATABLE_REF",
+                                        "PARTY_REF",
+                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "LOCATABLE_REF"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/LOCATABLE_REF"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "PARTY_REF"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/PARTY_REF"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ACCESS_GROUP_REF"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -14923,7 +15399,6 @@
         "DV_URI": {
             "type": "object",
             "required": [
-                "value"
             ],
             "properties": {
                 "value": {
@@ -16059,8 +16534,7 @@
                 "archetype_node_id",
                 "name",
                 "description",
-                "action_archetype_id",
-                "timing"
+                "action_archetype_id"
             ],
             "properties": {
                 "uid": {

--- a/components/openehr_api_1.1.0_all.json
+++ b/components/openehr_api_1.1.0_all.json
@@ -376,7 +376,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer"
             ],
@@ -3692,7 +3691,6 @@
         "CONTRIBUTION": {
             "type": "object",
             "required": [
-                "uid",
                 "audit",
                 "versions"
             ],
@@ -3769,14 +3767,8 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "COMPOSITION",
-                                            "FOLDER",
-                                            "EHR_STATUS",
-                                            "ROLE",
-                                            "AGENT",
-                                            "GROUP",
-                                            "ORGANISATION",
-                                            "PERSON"
+                                            "ORIGINAL_VERSION",
+                                            "IMPORTED_VERSION"
                                         ]
                                     }
                                 }
@@ -3785,7 +3777,7 @@
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "COMPOSITION"
+                                            "const": "ORIGINAL_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3793,14 +3785,14 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/COMPOSITION"
+                                    "$ref": "#/definitions/ORIGINAL_VERSION"
                                 }
                             },
                             {
                                 "if": {
                                     "properties": {
                                         "_type": {
-                                            "const": "FOLDER"
+                                            "const": "IMPORTED_VERSION"
                                         }
                                     },
                                     "required": [
@@ -3808,97 +3800,7 @@
                                     ]
                                 },
                                 "then": {
-                                    "$ref": "#/definitions/FOLDER"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "EHR_STATUS"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/EHR_STATUS"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ROLE"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ROLE"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "AGENT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/AGENT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "GROUP"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/GROUP"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ORGANISATION"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ORGANISATION"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PERSON"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PERSON"
+                                    "$ref": "#/definitions/IMPORTED_VERSION"
                                 }
                             }
                         ]
@@ -4198,7 +4100,6 @@
             "required": [
                 "contribution",
                 "commit_audit",
-                "uid",
                 "lifecycle_state"
             ],
             "properties": {
@@ -12281,7 +12182,6 @@
             "type": "object",
             "required": [
                 "system_id",
-                "time_committed",
                 "change_type",
                 "committer",
                 "reason",

--- a/components/openehr_rm_1.0.2_all.json
+++ b/components/openehr_rm_1.0.2_all.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_rm_1.0.3_all.json",
+    "$id": "https://specifications.openehr.org/releases/ITS-JSON/latest/components/openehr_rm_1.0.2_all.json",
     "allOf": [
         {
             "required": [
@@ -9664,66 +9664,6 @@
                 "careflow_step": {
                     "$ref": "#/definitions/DV_CODED_TEXT"
                 },
-                "reason": {
-                    "type": "array",
-                    "items": {
-                        "allOf": [
-                            {
-                                "properties": {
-                                    "_type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "DV_CODED_TEXT",
-                                            "DV_TEXT"
-                                        ]
-                                    }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "DV_CODED_TEXT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/DV_CODED_TEXT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "DV_TEXT"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/DV_TEXT"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "not": {
-                                        "required": [
-                                            "_type"
-                                        ]
-                                    }
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/DV_TEXT"
-                                }
-                            }
-                        ]
-                    }
-                },
                 "_type": {
                     "type": "string",
                     "const": "ISM_TRANSITION"
@@ -9814,7 +9754,8 @@
             "type": "object",
             "required": [
                 "function",
-                "performer"
+                "performer",
+                "mode"
             ],
             "properties": {
                 "function": {

--- a/components/openehr_rm_1.0.4_all.json
+++ b/components/openehr_rm_1.0.4_all.json
@@ -131,12 +131,12 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "CAPABILITY"
+                        "const": "ELEMENT"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/CAPABILITY"
+                "$ref": "#/definitions/ELEMENT"
             }
         },
         {
@@ -149,18 +149,6 @@
             },
             "then": {
                 "$ref": "#/definitions/PERSON"
-            }
-        },
-        {
-            "if": {
-                "properties": {
-                    "_type": {
-                        "const": "ADDRESS"
-                    }
-                }
-            },
-            "then": {
-                "$ref": "#/definitions/ADDRESS"
             }
         },
         {
@@ -191,12 +179,36 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "PARTY_IDENTITY"
+                        "const": "AGENT"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/PARTY_IDENTITY"
+                "$ref": "#/definitions/AGENT"
+            }
+        },
+        {
+            "if": {
+               "properties": {
+                  "_type": {
+                        "const": "GROUP"
+                  }
+               }
+            },
+            "then": {
+               "$ref": "#/definitions/GROUP"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "HISTORY"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/HISTORY"
             }
         },
         {
@@ -209,6 +221,42 @@
             },
             "then": {
                 "$ref": "#/definitions/ITEM_TREE"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ITEM_TABLE"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ITEM_TABLE"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ITEM_LIST"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ITEM_LIST"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ITEM_SINGLE"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ITEM_SINGLE"
             }
         },
         {
@@ -472,8 +520,7 @@
                 "ehr_id",
                 "time_created",
                 "ehr_access",
-                "ehr_status",
-                "contributions"
+                "ehr_status"
             ],
             "properties": {
                 "system_id": {
@@ -493,7 +540,6 @@
                                     "type": "string",
                                     "enum": [
                                         "LOCATABLE_REF",
-                                        "PARTY_REF",
                                         "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
@@ -513,21 +559,6 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
                             }
                         },
                         {
@@ -582,8 +613,6 @@
                                     "type": "string",
                                     "enum": [
                                         "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
@@ -602,36 +631,6 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -671,8 +670,6 @@
                                     "type": "string",
                                     "enum": [
                                         "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
@@ -691,36 +688,6 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -762,8 +729,6 @@
                                         "type": "string",
                                         "enum": [
                                             "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
@@ -782,36 +747,6 @@
                                 },
                                 "then": {
                                     "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -853,57 +788,9 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "LOCATABLE_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -1071,50 +958,6 @@
                 "_type": {
                     "type": "string",
                     "const": "REVISION_HISTORY_ITEM"
-                }
-            },
-            "additionalProperties": false
-        },
-        "ARCHETYPE_HRID": {
-            "type": "object",
-            "required": [
-                "namespace",
-                "rm_publisher",
-                "rm_package",
-                "rm_class",
-                "concept_id",
-                "release_version",
-                "version_status",
-                "build_count"
-            ],
-            "properties": {
-                "namespace": {
-                    "type": "string"
-                },
-                "rm_publisher": {
-                    "type": "string"
-                },
-                "rm_package": {
-                    "type": "string"
-                },
-                "rm_class": {
-                    "type": "string"
-                },
-                "concept_id": {
-                    "type": "string"
-                },
-                "release_version": {
-                    "type": "string"
-                },
-                "version_status": {
-                    "$ref": "#/definitions/VERSION_STATUS"
-                },
-                "build_count": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "ARCHETYPE_HRID"
                 }
             },
             "additionalProperties": false
@@ -2731,6 +2574,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -3021,26 +2865,6 @@
             },
             "additionalProperties": false
         },
-        "GENERIC_ID": {
-            "type": "object",
-            "required": [
-                "value",
-                "scheme"
-            ],
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "scheme": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "GENERIC_ID"
-                }
-            },
-            "additionalProperties": false
-        },
         "RESOURCE_DESCRIPTION": {
             "type": "object",
             "required": [
@@ -3081,6 +2905,26 @@
                 "_type": {
                     "type": "string",
                     "const": "RESOURCE_DESCRIPTION"
+                }
+            },
+            "additionalProperties": false
+        },
+        "GENERIC_ID": {
+            "type": "object",
+            "required": [
+                "value",
+                "scheme"
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "scheme": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "GENERIC_ID"
                 }
             },
             "additionalProperties": false
@@ -3855,22 +3699,6 @@
             },
             "additionalProperties": false
         },
-        "ISO8601_TYPE": {
-            "type": "object",
-            "required": [
-            ],
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "ISO8601_TYPE"
-                }
-            },
-            "description": "Parent of ISO8601 types.",
-            "additionalProperties": false
-        },
         "CONTRIBUTION": {
             "type": "object",
             "required": [
@@ -3948,57 +3776,9 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "LOCATABLE_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -4268,57 +4048,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -4434,7 +4166,148 @@
                     "$ref": "#/definitions/DV_CODED_TEXT"
                 },
                 "data": {
-                    "type": "object"
+                    "allOf": [
+                        {
+                            "required": [
+                                "_type"
+                            ],
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "COMPOSITION",
+                                        "FOLDER",
+                                        "EHR_STATUS",
+                                        "ROLE",
+                                        "AGENT",
+                                        "GROUP",
+                                        "ORGANISATION",
+                                        "PERSON"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "COMPOSITION"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/COMPOSITION"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "FOLDER"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/FOLDER"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "EHR_STATUS"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/EHR_STATUS"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ROLE"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ROLE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "AGENT"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/AGENT"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "GROUP"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/GROUP"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ORGANISATION"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ORGANISATION"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "PERSON"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/PERSON"
+                            }
+                        }
+                    ]
                 },
                 "_type": {
                     "type": "string",
@@ -4841,57 +4714,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -5501,9 +5326,6 @@
                 "magnitude": {
                     "type": "number"
                 },
-                "property": {
-                    "$ref": "#/definitions/CODE_PHRASE"
-                },
                 "units": {
                     "type": "string"
                 },
@@ -5537,57 +5359,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -5664,9 +5438,6 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
@@ -5954,6 +5725,22 @@
             },
             "additionalProperties": false
         },
+        "INTERNET_ID": {
+            "type": "object",
+            "required": [
+                "value"
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "INTERNET_ID"
+                }
+            },
+            "additionalProperties": false
+        },
         "TERMINOLOGY_CODE": {
             "type": "object",
             "required": [
@@ -5986,6 +5773,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities",
                 "performer"
@@ -6227,6 +6015,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -6517,22 +6306,6 @@
             },
             "additionalProperties": false
         },
-        "INTERNET_ID": {
-            "type": "object",
-            "required": [
-                "value"
-            ],
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "INTERNET_ID"
-                }
-            },
-            "additionalProperties": false
-        },
         "MESSAGE": {
             "type": "object",
             "required": [
@@ -6710,6 +6483,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -7588,57 +7362,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -9150,6 +8876,50 @@
             },
             "additionalProperties": false
         },
+        "RESOURCE_DESCRIPTION_ITEM": {
+            "type": "object",
+            "required": [
+                "language",
+                "purpose"
+            ],
+            "properties": {
+                "language": {
+                    "$ref": "#/definitions/CODE_PHRASE"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "use": {
+                    "type": "string"
+                },
+                "misuse": {
+                    "type": "string"
+                },
+                "copyright": {
+                    "type": "string"
+                },
+                "original_resource_uri": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "other_details": {
+                    "type": "object"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "RESOURCE_DESCRIPTION_ITEM"
+                }
+            },
+            "additionalProperties": false
+        },
         "CONTACT": {
             "type": "object",
             "required": [
@@ -9285,51 +9055,6 @@
                 "_type": {
                     "type": "string",
                     "const": "CONTACT"
-                }
-            },
-            "additionalProperties": false
-        },
-        "RESOURCE_DESCRIPTION_ITEM": {
-            "type": "object",
-            "required": [
-                "language",
-                "purpose",
-                "other_details"
-            ],
-            "properties": {
-                "language": {
-                    "$ref": "#/definitions/TERMINOLOGY_CODE"
-                },
-                "purpose": {
-                    "type": "string"
-                },
-                "keywords": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "use": {
-                    "type": "string"
-                },
-                "misuse": {
-                    "type": "string"
-                },
-                "copyright": {
-                    "type": "string"
-                },
-                "original_resource_uri": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "other_details": {
-                    "type": "object"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "RESOURCE_DESCRIPTION_ITEM"
                 }
             },
             "additionalProperties": false
@@ -9927,57 +9652,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -10184,57 +9861,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -10427,6 +10056,7 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
+                "archetype_details",
                 "name"
             ],
             "properties": {
@@ -10643,74 +10273,6 @@
                             }
                         ]
                     }
-                },
-                "details": {
-                    "allOf": [
-                        {
-                            "required": [
-                                "_type"
-                            ],
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "ITEM_SINGLE",
-                                        "ITEM_TREE",
-                                        "ITEM_LIST",
-                                        "ITEM_TABLE"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ITEM_SINGLE"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ITEM_SINGLE"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ITEM_TREE"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ITEM_TREE"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ITEM_LIST"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ITEM_LIST"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ITEM_TABLE"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ITEM_TABLE"
-                            }
-                        }
-                    ]
                 },
                 "_type": {
                     "type": "string",
@@ -10998,6 +10560,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -12064,10 +11627,7 @@
                     "type": "string"
                 },
                 "other_details": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "_type": {
                     "type": "string",
@@ -13054,6 +12614,72 @@
             },
             "additionalProperties": false
         },
+        "LOCATABLE_REF": {
+            "type": "object",
+            "required": [
+                "id",
+                "namespace",
+                "type"
+            ],
+            "properties": {
+                "id": {
+                    "allOf": [
+                        {
+                            "required": [
+                                "_type"
+                            ],
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "OBJECT_VERSION_ID",
+                                        "HIER_OBJECT_ID"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "OBJECT_VERSION_ID"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/OBJECT_VERSION_ID"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "HIER_OBJECT_ID"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/HIER_OBJECT_ID"
+                            }
+                        }
+                    ]
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "LOCATABLE_REF"
+                }
+            },
+            "additionalProperties": false
+        },
         "DATE_TIME": {
             "type": "object",
             "required": [
@@ -13278,72 +12904,6 @@
             },
             "additionalProperties": false
         },
-        "LOCATABLE_REF": {
-            "type": "object",
-            "required": [
-                "id",
-                "namespace",
-                "type"
-            ],
-            "properties": {
-                "id": {
-                    "allOf": [
-                        {
-                            "required": [
-                                "_type"
-                            ],
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "OBJECT_VERSION_ID",
-                                        "HIER_OBJECT_ID"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_VERSION_ID"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_VERSION_ID"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "HIER_OBJECT_ID"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/HIER_OBJECT_ID"
-                            }
-                        }
-                    ]
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "path": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "LOCATABLE_REF"
-                }
-            },
-            "additionalProperties": false
-        },
         "LIST": {
             "type": "object",
             "required": [
@@ -13490,6 +13050,7 @@
         "DV_EHR_URI": {
             "type": "object",
             "required": [
+               "value"
             ],
             "properties": {
                 "value": {
@@ -14358,6 +13919,7 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "language",
                 "territory",
@@ -14669,6 +14231,7 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "subject",
                 "is_queryable",
@@ -15014,7 +14577,7 @@
             ],
             "properties": {
                 "language": {
-                    "$ref": "#/definitions/TERMINOLOGY_CODE"
+                    "$ref": "#/definitions/CODE_PHRASE"
                 },
                 "author": {
                     "type": "object"
@@ -15426,57 +14989,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -15597,6 +15112,7 @@
         "DV_URI": {
             "type": "object",
             "required": [
+               "value"
             ],
             "properties": {
                 "value": {
@@ -16731,7 +16247,8 @@
             "required": [
                 "archetype_node_id",
                 "name",
-                "description"
+                "description",
+                "action_archetype_id"
             ],
             "properties": {
                 "uid": {

--- a/components/openehr_rm_1.1.0_all.json
+++ b/components/openehr_rm_1.1.0_all.json
@@ -131,12 +131,12 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "CAPABILITY"
+                        "const": "ELEMENT"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/CAPABILITY"
+                "$ref": "#/definitions/ELEMENT"
             }
         },
         {
@@ -149,18 +149,6 @@
             },
             "then": {
                 "$ref": "#/definitions/PERSON"
-            }
-        },
-        {
-            "if": {
-                "properties": {
-                    "_type": {
-                        "const": "ADDRESS"
-                    }
-                }
-            },
-            "then": {
-                "$ref": "#/definitions/ADDRESS"
             }
         },
         {
@@ -191,12 +179,36 @@
             "if": {
                 "properties": {
                     "_type": {
-                        "const": "PARTY_IDENTITY"
+                        "const": "AGENT"
                     }
                 }
             },
             "then": {
-                "$ref": "#/definitions/PARTY_IDENTITY"
+                "$ref": "#/definitions/AGENT"
+            }
+        },
+        {
+            "if": {
+               "properties": {
+                  "_type": {
+                        "const": "GROUP"
+                  }
+               }
+            },
+            "then": {
+               "$ref": "#/definitions/GROUP"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "HISTORY"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/HISTORY"
             }
         },
         {
@@ -209,6 +221,42 @@
             },
             "then": {
                 "$ref": "#/definitions/ITEM_TREE"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ITEM_TABLE"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ITEM_TABLE"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ITEM_LIST"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ITEM_LIST"
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "_type": {
+                        "const": "ITEM_SINGLE"
+                    }
+                }
+            },
+            "then": {
+                "$ref": "#/definitions/ITEM_SINGLE"
             }
         },
         {
@@ -472,8 +520,7 @@
                 "ehr_id",
                 "time_created",
                 "ehr_access",
-                "ehr_status",
-                "contributions"
+                "ehr_status"
             ],
             "properties": {
                 "system_id": {
@@ -493,7 +540,6 @@
                                     "type": "string",
                                     "enum": [
                                         "LOCATABLE_REF",
-                                        "PARTY_REF",
                                         "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
@@ -513,21 +559,6 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
                             }
                         },
                         {
@@ -582,8 +613,6 @@
                                     "type": "string",
                                     "enum": [
                                         "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
@@ -602,36 +631,6 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -671,8 +670,6 @@
                                     "type": "string",
                                     "enum": [
                                         "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
@@ -691,36 +688,6 @@
                             },
                             "then": {
                                 "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -762,8 +729,6 @@
                                         "type": "string",
                                         "enum": [
                                             "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
@@ -782,36 +747,6 @@
                                 },
                                 "then": {
                                     "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -854,8 +789,6 @@
                                         "type": "string",
                                         "enum": [
                                             "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
@@ -874,36 +807,6 @@
                                 },
                                 "then": {
                                     "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -945,57 +848,9 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "LOCATABLE_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -2823,6 +2678,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -3113,26 +2969,6 @@
             },
             "additionalProperties": false
         },
-        "GENERIC_ID": {
-            "type": "object",
-            "required": [
-                "value",
-                "scheme"
-            ],
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "scheme": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "GENERIC_ID"
-                }
-            },
-            "additionalProperties": false
-        },
         "RESOURCE_DESCRIPTION": {
             "type": "object",
             "required": [
@@ -3173,6 +3009,26 @@
                 "_type": {
                     "type": "string",
                     "const": "RESOURCE_DESCRIPTION"
+                }
+            },
+            "additionalProperties": false
+        },
+        "GENERIC_ID": {
+            "type": "object",
+            "required": [
+                "value",
+                "scheme"
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "scheme": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "GENERIC_ID"
                 }
             },
             "additionalProperties": false
@@ -3947,22 +3803,6 @@
             },
             "additionalProperties": false
         },
-        "ISO8601_TYPE": {
-            "type": "object",
-            "required": [
-            ],
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "ISO8601_TYPE"
-                }
-            },
-            "description": "Parent of ISO8601 types.",
-            "additionalProperties": false
-        },
         "CONTRIBUTION": {
             "type": "object",
             "required": [
@@ -4040,57 +3880,9 @@
                                     "_type": {
                                         "type": "string",
                                         "enum": [
-                                            "LOCATABLE_REF",
-                                            "PARTY_REF",
-                                            "ACCESS_GROUP_REF",
                                             "OBJECT_REF"
                                         ]
                                     }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "LOCATABLE_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/LOCATABLE_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "PARTY_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/PARTY_REF"
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "_type": {
-                                            "const": "ACCESS_GROUP_REF"
-                                        }
-                                    },
-                                    "required": [
-                                        "_type"
-                                    ]
-                                },
-                                "then": {
-                                    "$ref": "#/definitions/ACCESS_GROUP_REF"
                                 }
                             },
                             {
@@ -4428,57 +4220,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -4594,7 +4338,148 @@
                     "$ref": "#/definitions/DV_CODED_TEXT"
                 },
                 "data": {
-                    "type": "object"
+                    "allOf": [
+                        {
+                            "required": [
+                                "_type"
+                            ],
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "COMPOSITION",
+                                        "FOLDER",
+                                        "EHR_STATUS",
+                                        "ROLE",
+                                        "AGENT",
+                                        "GROUP",
+                                        "ORGANISATION",
+                                        "PERSON"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "COMPOSITION"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/COMPOSITION"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "FOLDER"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/FOLDER"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "EHR_STATUS"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/EHR_STATUS"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ROLE"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ROLE"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "AGENT"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/AGENT"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "GROUP"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/GROUP"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "ORGANISATION"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/ORGANISATION"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "PERSON"
+                                    }
+                                },
+                                "required": [
+                                    "_type"
+                                ]
+                            },
+                            "then": {
+                                "$ref": "#/definitions/PERSON"
+                            }
+                        }
+                    ]
                 },
                 "_type": {
                     "type": "string",
@@ -5004,57 +4889,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -5664,9 +5501,6 @@
                 "magnitude": {
                     "type": "number"
                 },
-                "property": {
-                    "$ref": "#/definitions/CODE_PHRASE"
-                },
                 "units": {
                     "type": "string"
                 },
@@ -5706,57 +5540,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -5833,57 +5619,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -6123,6 +5861,22 @@
             },
             "additionalProperties": false
         },
+        "INTERNET_ID": {
+            "type": "object",
+            "required": [
+                "value"
+            ],
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "INTERNET_ID"
+                }
+            },
+            "additionalProperties": false
+        },
         "TERMINOLOGY_CODE": {
             "type": "object",
             "required": [
@@ -6155,6 +5909,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities",
                 "performer"
@@ -6396,6 +6151,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -6686,22 +6442,6 @@
             },
             "additionalProperties": false
         },
-        "INTERNET_ID": {
-            "type": "object",
-            "required": [
-                "value"
-            ],
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "INTERNET_ID"
-                }
-            },
-            "additionalProperties": false
-        },
         "MESSAGE": {
             "type": "object",
             "required": [
@@ -6879,6 +6619,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -7757,57 +7498,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -9388,6 +9081,50 @@
             },
             "additionalProperties": false
         },
+        "RESOURCE_DESCRIPTION_ITEM": {
+            "type": "object",
+            "required": [
+                "language",
+                "purpose"
+            ],
+            "properties": {
+                "language": {
+                    "$ref": "#/definitions/CODE_PHRASE"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "use": {
+                    "type": "string"
+                },
+                "misuse": {
+                    "type": "string"
+                },
+                "copyright": {
+                    "type": "string"
+                },
+                "original_resource_uri": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "other_details": {
+                    "type": "object"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "RESOURCE_DESCRIPTION_ITEM"
+                }
+            },
+            "additionalProperties": false
+        },
         "CONTACT": {
             "type": "object",
             "required": [
@@ -9523,51 +9260,6 @@
                 "_type": {
                     "type": "string",
                     "const": "CONTACT"
-                }
-            },
-            "additionalProperties": false
-        },
-        "RESOURCE_DESCRIPTION_ITEM": {
-            "type": "object",
-            "required": [
-                "language",
-                "purpose",
-                "other_details"
-            ],
-            "properties": {
-                "language": {
-                    "$ref": "#/definitions/TERMINOLOGY_CODE"
-                },
-                "purpose": {
-                    "type": "string"
-                },
-                "keywords": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "use": {
-                    "type": "string"
-                },
-                "misuse": {
-                    "type": "string"
-                },
-                "copyright": {
-                    "type": "string"
-                },
-                "original_resource_uri": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "other_details": {
-                    "type": "object"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "RESOURCE_DESCRIPTION_ITEM"
                 }
             },
             "additionalProperties": false
@@ -10165,57 +9857,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -10422,57 +10066,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -10665,6 +10261,7 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
+                "archetype_details",
                 "name"
             ],
             "properties": {
@@ -11236,6 +10833,7 @@
             "required": [
                 "uid",
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "identities"
             ],
@@ -12302,10 +11900,7 @@
                     "type": "string"
                 },
                 "other_details": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "_type": {
                     "type": "string",
@@ -13292,6 +12887,72 @@
             },
             "additionalProperties": false
         },
+        "LOCATABLE_REF": {
+            "type": "object",
+            "required": [
+                "id",
+                "namespace",
+                "type"
+            ],
+            "properties": {
+                "id": {
+                    "allOf": [
+                        {
+                            "required": [
+                                "_type"
+                            ],
+                            "properties": {
+                                "_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "OBJECT_VERSION_ID",
+                                        "HIER_OBJECT_ID"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "OBJECT_VERSION_ID"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/OBJECT_VERSION_ID"
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "_type": {
+                                        "const": "HIER_OBJECT_ID"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "#/definitions/HIER_OBJECT_ID"
+                            }
+                        }
+                    ]
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "_type": {
+                    "type": "string",
+                    "const": "LOCATABLE_REF"
+                }
+            },
+            "additionalProperties": false
+        },
         "DATE_TIME": {
             "type": "object",
             "required": [
@@ -13516,72 +13177,6 @@
             },
             "additionalProperties": false
         },
-        "LOCATABLE_REF": {
-            "type": "object",
-            "required": [
-                "id",
-                "namespace",
-                "type"
-            ],
-            "properties": {
-                "id": {
-                    "allOf": [
-                        {
-                            "required": [
-                                "_type"
-                            ],
-                            "properties": {
-                                "_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "OBJECT_VERSION_ID",
-                                        "HIER_OBJECT_ID"
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "OBJECT_VERSION_ID"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/OBJECT_VERSION_ID"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "HIER_OBJECT_ID"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "$ref": "#/definitions/HIER_OBJECT_ID"
-                            }
-                        }
-                    ]
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "path": {
-                    "type": "string"
-                },
-                "_type": {
-                    "type": "string",
-                    "const": "LOCATABLE_REF"
-                }
-            },
-            "additionalProperties": false
-        },
         "LIST": {
             "type": "object",
             "required": [
@@ -13728,6 +13323,7 @@
         "DV_EHR_URI": {
             "type": "object",
             "required": [
+               "value"
             ],
             "properties": {
                 "value": {
@@ -14629,6 +14225,7 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "language",
                 "territory",
@@ -14940,6 +14537,7 @@
             "type": "object",
             "required": [
                 "archetype_node_id",
+                "archetype_details",
                 "name",
                 "subject",
                 "is_queryable",
@@ -15285,7 +14883,7 @@
             ],
             "properties": {
                 "language": {
-                    "$ref": "#/definitions/TERMINOLOGY_CODE"
+                    "$ref": "#/definitions/CODE_PHRASE"
                 },
                 "author": {
                     "type": "object"
@@ -15697,57 +15295,9 @@
                                 "_type": {
                                     "type": "string",
                                     "enum": [
-                                        "LOCATABLE_REF",
-                                        "PARTY_REF",
-                                        "ACCESS_GROUP_REF",
                                         "OBJECT_REF"
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "LOCATABLE_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/LOCATABLE_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "PARTY_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/PARTY_REF"
-                            }
-                        },
-                        {
-                            "if": {
-                                "properties": {
-                                    "_type": {
-                                        "const": "ACCESS_GROUP_REF"
-                                    }
-                                },
-                                "required": [
-                                    "_type"
-                                ]
-                            },
-                            "then": {
-                                "$ref": "#/definitions/ACCESS_GROUP_REF"
                             }
                         },
                         {
@@ -15868,6 +15418,7 @@
         "DV_URI": {
             "type": "object",
             "required": [
+               "value"
             ],
             "properties": {
                 "value": {
@@ -17002,7 +16553,8 @@
             "required": [
                 "archetype_node_id",
                 "name",
-                "description"
+                "description",
+                "action_archetype_id"
             ],
             "properties": {
                 "uid": {


### PR DESCRIPTION
Some types were not validating using the *all JSON schemas and detected some entry points were missing, then checked other internal structures and detected other issues and some simplifications/formalizations. These changes were validated against each RM version. The *api schemas are based on the openEHR REST API payloads that have some OBJECT_REFs resolved to the actual object. Also the schemas for RM 1.0.2 were not included, I have created them by modifying the 1.0.3 schemas.

To check the specific changes, just do a diff from the RM schema to the corresponding schema currently published by the SEC.

For context check this thread https://discourse.openehr.org/t/multi-rm-json-schema-validation-and-current-schema-issues/3002

@pieterbos this is a list of changes:

1. Demographic top-level classes were not included in the root validator (entry point if-then in the schemas), including: ROLE, AGENT, GROUP, PERSON and ORGANIZATION.
2. EHR.ehr_access won't be of type PARTY_REF, so I removed it (and I guess it won't be LOCATABLE_REF neither but I need confirmation from the SEC)
3. EHR.ehr_status won't be PARTY_REF or ACCESS_GROUP_REF, so I removed those options.
4. EHR.directory won't be PARTY_REF or ACCESS_GROUP_REF, removed both
5. EHR.compositions won't PARTY_REF or ACCESS_GROUP_REF, removed both
6. EHR.contributions won't be LOCATABLE_REF, PARTY_REF or ACCESS_GROUP_REF, removed those options leaving only OBJECT_REF
7. PERSON.roles and PERSON.languages (really for all ACTOR's) in RM 1.0.3, added archetype_details as required, removed roles and languages from required.
8. Removed type ISO8601_TYPE from the RM 1.0.3 schema (I think because that type wasn't defined in that RM version, would need to double check)
9. Items in CONTRIBUTION.versions won't be LOCATABLE_REF, PARTY_REF or ACCESS_GROUP_REF so I removed them, the only option is OBJECT_REF.
10. ORIGINAL_VERSION.contribution won't be LOCATABLE_REF, PARTY_REF or ACCESS_GROUP_REF, only OBJECT_REF.
11. ORIGINAL_VERSION.data could be any of the top level LOCATABLE classes: COMPOSITION, FOLDER, EHR_STATUS, ROLE, AGENT, GROUP, ORGANISATION, PERSON. Before this was just "object" in the schema, so it doesn't validation the version.data at all.
12. X_VERSIONED_PARTY.owner_id **I think** won't be LOCATABLE_REF, PARTY_REF or ACCESS_GROUP_REF, I removed them.
13. DV_QUANTITY doesn't have a property named "property" in the RM, this was introduced because the AOM uses that property but it's from the C_DV_QUANTITY from the Archetype Profile model, so if it's not part of the RM, it shouldn't be part of the JSON schema based on the RM.
14. X_VERSIONED_COMPOSITION.owner_id **I think** won't be LOCATABLE_REF, PARTY_REF or ACCESS_GROUP_REF, I removed them. (same with X_VERSIONED_EHR_ACCESS, X_VERSIONED_OBJECT)
15. EXTRACT_ENTITY_MANIFEST.other_ids was "object" and I changed that to array<string> in RM 1.0.3
16. RESOURCE_DESCRIPTION_ITEM.other_details removed from required
17. FOLDER.archetype_details changed to required (I know this change might need to be reverted since the top level FOLDERs might have archetype_details but the subfolders might not, though there is sufficient information in systems to set the archetype_details of all the FOLDERs)
18. ORGANISATION added archetype_details as required and removed roles and languages from required (RM 1.0.3)
19. DV_EHR_URI added value as required
20. COMPOSITION added archetype_details as required (though it is optional in the model, this is required for all top level classes to be able to get the template_id to validate the LOCATABLE (this comment also applies to other classes like ORGANISATION, PERSON, AGENT, FOLDER, EHR_STATUS, ROLE, etc. mentioned above) To be correct this can be removed and the check be implemented as a rule in the software.
21. EHR_STATUS added archetype_details as required.
22. IMPORTED_VERSION.contributions removed possible types LOCATABLE_REF, PARTY_REF and ACCESS_GROUP_REF, since those won't be used there.
23. DV_URI.value added as required, it was missing.
24. ACTIVITY.action_archetype_id added to required